### PR TITLE
feat: migrate to `tree-sitter.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,13 +15,5 @@
   },
   "scripts": {
     "test": "tree-sitter test"
-  },
-  "tree-sitter": [
-    {
-      "scope": "source.scfg",
-      "file-types": [
-        "scfg"
-      ]
-    }
-  ]
+  }
 }

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,29 @@
+{
+  "grammars": [
+    {
+      "name": "scfg",
+      "camelcase": "Scfg",
+      "scope": "source.scfg",
+      "path": ".",
+      "file-types": [
+        "scfg"
+      ]
+    }
+  ],
+  "metadata": {
+    "version": "0.0.1",
+    "license": "MIT",
+    "description": "scfg grammar for tree-sitter",
+    "links": {
+      "repository": "https://github.com/tree-sitter/tree-sitter-scfg"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
Hey 👋 I'm putting up this PR because this file will be a requirement in 0.25, and this is one of the few remaining grammars out there that hasn't migrated, thanks.